### PR TITLE
Allow defining the name for the scaffold. GeneratorCommand.php

### DIFF
--- a/src/Commands/GeneratorCommand.php
+++ b/src/Commands/GeneratorCommand.php
@@ -466,6 +466,10 @@ abstract class GeneratorCommand extends Command
         if (!empty($route)) {
             $this->options['route'] = $route;
         }
+        
+        if (!empty($modelName)) {
+            $this->options['model-name'] = $modelName;
+        }
 
         return $this;
     }


### PR DESCRIPTION
It allows you to define the name for the scaffold, it is the same syntax used in Ruby on Rails. 

Example:
php artisan make:crud emergencies --model-name=Emergencies