### PR TITLE
fix(stubs): align generated views with current tablar conventions

### DIFF
--- a/src/stubs/views/create.stub
+++ b/src/stubs/views/create.stub
@@ -20,14 +20,7 @@
                 <div class="col-12 col-md-auto ms-auto d-print-none">
                     <div class="btn-list">
                         <a href="{{ route('{{modelRoute}}.index') }}" class="btn btn-primary d-none d-sm-inline-block">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/plus -->
-                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
-                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
-                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <line x1="12" y1="5" x2="12" y2="19"/>
-                                <line x1="5" y1="12" x2="19" y2="12"/>
-                            </svg>
+                            <i class="ti ti-list me-1"></i>
                             {{modelTitle}} List
                         </a>
                     </div>
@@ -38,7 +31,7 @@
     <!-- Page body -->
     <div class="page-body">
         <div class="container-xl">
-            @if(config('tablar','display_alert'))
+            @if(config('tablar.display_alert'))
                 @include('tablar::common.alert')
             @endif
             <div class="row row-deck row-cards">

--- a/src/stubs/views/edit.stub
+++ b/src/stubs/views/edit.stub
@@ -20,14 +20,7 @@
                 <div class="col-12 col-md-auto ms-auto d-print-none">
                     <div class="btn-list">
                         <a href="{{ route('{{modelRoute}}.index') }}" class="btn btn-primary d-none d-sm-inline-block">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/plus -->
-                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
-                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
-                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <line x1="12" y1="5" x2="12" y2="19"/>
-                                <line x1="5" y1="12" x2="19" y2="12"/>
-                            </svg>
+                            <i class="ti ti-list me-1"></i>
                             {{modelTitle}} List
                         </a>
                     </div>
@@ -38,7 +31,7 @@
     <!-- Page body -->
     <div class="page-body">
         <div class="container-xl">
-            @if(config('tablar','display_alert'))
+            @if(config('tablar.display_alert'))
                 @include('tablar::common.alert')
             @endif
             <div class="row row-deck row-cards">

--- a/src/stubs/views/form.stub
+++ b/src/stubs/views/form.stub
@@ -3,7 +3,7 @@
         <div class="text-end">
             <div class="d-flex">
                 <a href="#" class="btn btn-danger">Cancel</a>
-                <button type="submit" class="btn btn-primary ms-auto ajax-submit">Submit</button>
+                <button type="submit" class="btn btn-primary ms-auto ajax-submit-button has-spinner">Submit</button>
             </div>
         </div>
     </div>

--- a/src/stubs/views/index.stub
+++ b/src/stubs/views/index.stub
@@ -22,14 +22,7 @@
                 <div class="col-12 col-md-auto ms-auto d-print-none">
                     <div class="btn-list">
                         <a href="{{ route('{{modelRoute}}.create') }}" class="btn btn-primary d-none d-sm-inline-block">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/plus -->
-                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
-                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
-                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <line x1="12" y1="5" x2="12" y2="19"/>
-                                <line x1="5" y1="12" x2="19" y2="12"/>
-                            </svg>
+                            <i class="ti ti-plus me-1"></i>
                             Create {{modelTitle}}
                         </a>
                     </div>
@@ -40,7 +33,7 @@
     <!-- Page body -->
     <div class="page-body">
         <div class="container-xl">
-            @if(config('tablar','display_alert'))
+            @if(config('tablar.display_alert'))
                 @include('tablar::common.alert')
             @endif
             <div class="row row-deck row-cards">
@@ -75,14 +68,7 @@
                                     <th class="w-1"><input class="form-check-input m-0 align-middle" type="checkbox"
                                                            aria-label="Select all invoices"></th>
                                     <th class="w-1">No.
-                                        <!-- Download SVG icon from http://tabler-icons.io/i/chevron-up -->
-                                        <svg xmlns="http://www.w3.org/2000/svg"
-                                             class="icon icon-sm text-dark icon-thick" width="24" height="24"
-                                             viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
-                                             stroke-linecap="round" stroke-linejoin="round">
-                                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                            <polyline points="6 15 12 9 18 15"/>
-                                        </svg>
+                                        <i class="ti ti-chevron-up icon-sm text-dark"></i>
                                     </th>
                                     {{tableHeader}}
                                     <th class="w-1"></th>
@@ -119,8 +105,8 @@
                                                             @method('DELETE')
                                                             <button type="submit"
                                                                     onclick="if(!confirm('Do you Want to Proceed?')){return false;}"
-                                                                    class="dropdown-item text-red"><i
-                                                                    class="fa fa-fw fa-trash"></i>
+                                                                    class="dropdown-item text-red">
+                                                                <i class="ti ti-trash me-1"></i>
                                                                 Delete
                                                             </button>
                                                         </form>

--- a/src/stubs/views/show.stub
+++ b/src/stubs/views/show.stub
@@ -20,14 +20,7 @@
                 <div class="col-12 col-md-auto ms-auto d-print-none">
                     <div class="btn-list">
                         <a href="{{ route('{{modelRoute}}.index') }}" class="btn btn-primary d-none d-sm-inline-block">
-                            <!-- Download SVG icon from http://tabler-icons.io/i/plus -->
-                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
-                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
-                                 stroke-linecap="round" stroke-linejoin="round">
-                                <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-                                <line x1="12" y1="5" x2="12" y2="19"/>
-                                <line x1="5" y1="12" x2="19" y2="12"/>
-                            </svg>
+                            <i class="ti ti-list me-1"></i>
                             {{modelTitle}} List
                         </a>
                     </div>
@@ -40,7 +33,7 @@
         <div class="container-xl">
             <div class="row row-deck row-cards">
                 <div class="col-12">
-                    @if(config('tablar','display_alert'))
+                    @if(config('tablar.display_alert'))
                         @include('tablar::common.alert')
                     @endif
                     <div class="card">


### PR DESCRIPTION
Four stub bugs surfaced after layout audit against tablar's home/profile/settings stubs (which moved to ti-icon classes and use the documented config syntax):

1. config('tablar','display_alert') → config('tablar.display_alert') The 2-arg form returns 'display_alert' as a default value (truthy string) regardless of the config value, so the @include('tablar::common.alert') block ALWAYS rendered. Fixed in index/create/edit/show.

2. ajax-submit → ajax-submit-button has-spinner Lab's auto-binder targets .ajax-submit-button (verified resources/js/modules/ajax-request.js:219). The old class was a no-op, so generated forms posted as plain HTML and triggered a full page reload. Fixed in form.stub.

3. Inline SVG icons → <i class="ti ti-..."></i> tablar's current published stubs (home/profile/settings) use Tabler icon classes exclusively. Generator was emitting verbose hand-rolled SVG markup. Fixed in index/create/edit/show.

4. <i class="fa fa-fw fa-trash"> → <i class="ti ti-trash me-1"> Font Awesome reference in the index dropdown delete button — Tabler does not bundle FA. Fixed in index.stub.

Tests: 30/30 pass on sqlite, mysql/mariadb 10.11, pgsql 16.13.